### PR TITLE
Update to elasticsearch version 6.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'org.openkoreantext'
-version '6.1.1.2'
+version '6.1.3.2'
 
 apply plugin: 'java'
 apply plugin: 'maven'
@@ -20,7 +20,7 @@ configurations {
 }
 
 ext {
-    elasticsearchVersion = '6.1.1'
+    elasticsearchVersion = '6.1.3'
     openKoreanTextVersion = '2.1.0'
 }
 


### PR DESCRIPTION
Hi, elastic recently released the stack version 6.1.3 https://www.elastic.co/blog/elasticsearch-6-1-3-and-5-6-7-released which contains patches important for some of the users. This upgrades the plugin to make sure it is compatible with 6.1.3.